### PR TITLE
Remove unused import from template compiler test

### DIFF
--- a/ppdpy/tests/test_template_compiler.py
+++ b/ppdpy/tests/test_template_compiler.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from ppdpy import renders
 from ppdpy.exceptions import ExpressionSyntaxError, DirectiveSyntaxError
-from ppdpy.nodes import *
 
 
 class TestTemplates(TestCase):


### PR DESCRIPTION
This commit removes an unused import from template compiler test.